### PR TITLE
Additional functionality

### DIFF
--- a/lua/cmp-bibtex/util.lua
+++ b/lua/cmp-bibtex/util.lua
@@ -178,16 +178,22 @@ function M.completion_items(file)
   local contents = io.read("*a")
 
   if contents then
+    -- Match individual BibTeX entries
     local entries = contents:gmatch("@%w*%s*%b{}")
 
     for entry in entries do
+      -- Extract the key and type
       local key = entry:match("@%w*%s*{%s*(%w+),?")
+      local entry_type = entry:match("@(%w+)") or "unknown"
+
+      -- Extract other fields
       local author = latex_to_utf8(M.get_field(entry, "author"))
       local year = M.get_field(entry, "year")
       local title = latex_to_utf8(M.get_field(entry, "title"))
       local pages = latex_to_utf8(M.get_field(entry, "pages"))
       local journal = latex_to_utf8(M.get_field(entry, "journaltitle") or M.get_field(entry, "journal"))
 
+      -- Format documentation in APA-like style with type
       local apa_preview = "**" .. (author or "Unknown Author") .. ".** "
       if year and year ~= "NA" then
         apa_preview = apa_preview .. "(" .. year .. "). "
@@ -196,9 +202,11 @@ function M.completion_items(file)
         apa_preview = apa_preview .. "*" .. title .. ".* "
       end
       if journal and journal ~= "NA" then
-        apa_preview = apa_preview .. journal .. "."
+        apa_preview = apa_preview .. journal .. ". "
       end
+      apa_preview = apa_preview .. "\n\n{" .. entry_type .. "}" -- Add type in braces
 
+      -- Create the completion item
       if key then
         table.insert(ret, {
           label = key,

--- a/lua/cmp-bibtex/util.lua
+++ b/lua/cmp-bibtex/util.lua
@@ -62,7 +62,47 @@ function M.should_complete(context)
     context.cursor.character,
     {}
   )[1]
-  return string.match(line, "@$") or string.match(line, "\\cite%a?{$") or false
+
+  -- If the line ends with '@', trigger completion (as before)
+  if line:match("@$") then
+    return true
+  end
+
+  -- List of all commands we want matched
+  local citation_commands = {
+    "cite",
+    "footcite",
+    "footcites",
+    "parencite",
+    "parencites",
+    "textcite",
+    "textcites",
+    "autocite",
+    "autocites",
+    "smartcite",
+    "smartcites",
+    "supercite",
+    "citeyear",
+    "citeauthor",
+    "citetitle",
+    -- Custom
+    "citefirstlastauthor",
+    "citejournal",
+    "citefirstlastauthoryear",
+  }
+
+  -- Test each command. The pattern:
+  -- \\command - matches the command
+  -- %a? - optional letter after the command (e.g., cites)
+  -- .- - minimal match of arbitrary characters to reach the {
+  -- { - requires that a { exists after the command and any optional arguments
+  for _, cmd in ipairs(citation_commands) do
+    if line:match("\\" .. cmd .. "%a?.-{") then
+      return true
+    end
+  end
+
+  return false
 end
 
 -- Clean relative file paths for BibTeX files

--- a/lua/cmp-bibtex/util.lua
+++ b/lua/cmp-bibtex/util.lua
@@ -1,9 +1,26 @@
 local M = {}
 
+-- Extract a specific field from a BibTeX entry
 function M.get_field(entry, field)
-  return (string.match(entry, field .. "%s*=%s*%b{}") or "NA"):gsub(field .. "%s*=%s*", ""):gsub("[{}]", "")
+  -- Match the field and preserve the content within the outermost braces
+  local match = string.match(entry, field .. "%s*=%s*%b{}")
+  if match then
+    local content = match:match("{(.*)}") -- Extract inside the outermost {}
+    return content or "NA"
+  end
+  return "NA"
 end
 
+-- Convert a list of values into a dictionary-like table with keys
+function M.vals_to_keys(list)
+  local ret = {}
+  for _, v in ipairs(list) do
+    ret[v] = true
+  end
+  return ret
+end
+
+-- Extract BibTeX resource files linked in a LaTeX file
 function M.get_bibresources(context)
   local ret = {}
   if context.filetype == "tex" then
@@ -14,26 +31,28 @@ function M.get_bibresources(context)
       -- TODO: Support other methods of adding bib resources
       -- TODO: Exclude commented out lines
       local matches = line:gmatch("\\addbibresource%b{}")
-
       for match in matches do
-        local bib_file = match:gsub("(\\addbibresource{)(.*)(}%s*)", "%2")
-        table.insert(ret, bib_file)
+        local bib_file = match:match("\\addbibresource{(.*)}")
+        if bib_file then
+          table.insert(ret, bib_file)
+        end
       end
     end
   end
   return ret
 end
 
+-- Check if a file exists
 function M.file_exists(file)
   local f = io.open(file, "r")
-  if f ~= nil then
+  if f then
     io.close(f)
     return true
-  else
-    return false
   end
+  return false
 end
 
+-- Decide whether to trigger BibTeX completion
 function M.should_complete(context)
   local line = vim.api.nvim_buf_get_text(
     context.bufnr,
@@ -43,18 +62,15 @@ function M.should_complete(context)
     context.cursor.character,
     {}
   )[1]
-  if string.match(line, "@$") or string.match(line, "\\cite%a?{$") then
-    return true
-  end
-  return false
+  return string.match(line, "@$") or string.match(line, "\\cite%a?{$") or false
 end
 
+-- Clean relative file paths for BibTeX files
 function M.clean_filenames(files)
   local ret = {}
   for _, v in ipairs(files) do
     local filename = vim.fn.expand(v)
     if not string.match(filename, "^/") then
-      -- TODO: get actual filename from request context
       filename = vim.fn.expand("%:p:h") .. "/" .. filename
     end
     table.insert(ret, filename)
@@ -62,14 +78,7 @@ function M.clean_filenames(files)
   return ret
 end
 
-function M.vals_to_keys(list)
-  local ret = {}
-  for _, v in ipairs(list) do
-    ret[v] = true
-  end
-  return ret
-end
-
+-- Flatten a nested table one level deep
 function M.flatten_once(tab)
   local ret = {}
   for _, vi in pairs(tab) do
@@ -80,6 +89,88 @@ function M.flatten_once(tab)
   return ret
 end
 
+-- Convert LaTeX-encoded text to UTF-8
+local function latex_to_utf8(text)
+  if not text then
+    return ""
+  end
+
+  local replacements = {
+    -- Skandinavian accents
+    ['\\"a'] = "ä",
+    ['\\"A'] = "Ä",
+    ['\\"o'] = "ö",
+    ['\\"O'] = "Ö",
+    ["\\aa"] = "å",
+    ["\\AA"] = "Å",
+
+    -- German accents
+    ['\\"u'] = "ü",
+    ['\\"U'] = "Ü",
+    ["\\ss"] = "ß",
+
+    -- Hungarian and misc accents
+    ["\\'a"] = "á",
+    ["\\'A"] = "Á",
+    ["\\'e"] = "é",
+    ["\\'E"] = "É",
+    ["\\'i"] = "í",
+    ["\\'I"] = "Í",
+    ["\\'o"] = "ó",
+    ["\\'O"] = "Ó",
+    ["\\'u"] = "ú",
+    ["\\'U"] = "Ú",
+    ['\\"u'] = "ű",
+    ['\\"U'] = "Ű",
+
+    -- French accents
+    ["\\`a"] = "à",
+    ["\\`A"] = "À",
+    ["\\`e"] = "è",
+    ["\\`E"] = "È",
+    ["\\`u"] = "ù",
+    ["\\`U"] = "Ù",
+    ["\\^a"] = "â",
+    ["\\^A"] = "Â",
+    ["\\^e"] = "ê",
+    ["\\^E"] = "Ê",
+    ["\\^o"] = "ô",
+    ["\\^O"] = "Ô",
+    ["\\^u"] = "û",
+    ["\\^U"] = "Û",
+
+    -- Spanish and Portugese accents
+    ["\\~n"] = "ñ",
+    ["\\~N"] = "Ñ",
+    ["\\~a"] = "ã",
+    ["\\~A"] = "Ã",
+    ["\\~o"] = "õ",
+    ["\\~O"] = "Õ",
+
+    -- General accents
+    ["\\c{c}"] = "ç",
+    ["\\c{C}"] = "Ç",
+
+    -- Commands
+    ["\\textsuperscript"] = "⁺",
+    ["\\textsubscript"] = "₋",
+  }
+
+  for k, v in pairs(replacements) do
+    text = text:gsub(k, v)
+  end
+
+  -- Handle dashes at the end to avoid interfering with other replacements
+  text = text:gsub("%-%-%-", "—") -- Replace "---" with em-dash
+  text = text:gsub("%-%-", "–") -- Replace "--" with en-dash
+
+  -- Remove all curly braces
+  text = text:gsub("[{}]", "")
+
+  return text
+end
+
+-- Generate completion items from a BibTeX file
 function M.completion_items(file)
   local ret = {}
 
@@ -90,18 +181,13 @@ function M.completion_items(file)
     local entries = contents:gmatch("@%w*%s*%b{}")
 
     for entry in entries do
-      local key = entry:match("@%w*%s*{%c?%w*,?"):gsub("@%w*%s*{%c?", ""):gsub(",?", "")
-      local author = M.get_field(entry, "author")
+      local key = entry:match("@%w*%s*{%s*(%w+),?")
+      local author = latex_to_utf8(M.get_field(entry, "author"))
       local year = M.get_field(entry, "year")
-      local title = M.get_field(entry, "title")
-      local journal = M.get_field(entry, "journaltitle") or M.get_field(entry, "journal")
-      local volume = M.get_field(entry, "volume")
-      local number = M.get_field(entry, "number")
-      local pages = M.get_field(entry, "pages")
-      local publisher = M.get_field(entry, "publisher")
-      local entry_type = entry:match("@%w*"):sub(2):lower() -- Ex: article, book
+      local title = latex_to_utf8(M.get_field(entry, "title"))
+      local pages = latex_to_utf8(M.get_field(entry, "pages"))
+      local journal = latex_to_utf8(M.get_field(entry, "journaltitle") or M.get_field(entry, "journal"))
 
-      -- Format APA-stil preview
       local apa_preview = "**" .. (author or "Unknown Author") .. ".** "
       if year and year ~= "NA" then
         apa_preview = apa_preview .. "(" .. year .. "). "
@@ -109,33 +195,15 @@ function M.completion_items(file)
       if title and title ~= "NA" then
         apa_preview = apa_preview .. "*" .. title .. ".* "
       end
-
-      if entry_type == "article" and journal and journal ~= "NA" then
-        apa_preview = apa_preview .. journal
-        if volume and volume ~= "NA" then
-          apa_preview = apa_preview .. ", *" .. volume .. "*"
-        end
-        if number and number ~= "NA" then
-          apa_preview = apa_preview .. "(" .. number .. ")"
-        end
-        if pages and pages ~= "NA" then
-          apa_preview = apa_preview .. ", " .. pages
-        end
-        apa_preview = apa_preview .. "."
-      elseif publisher and publisher ~= "NA" then
-        apa_preview = apa_preview .. publisher .. "."
+      if journal and journal ~= "NA" then
+        apa_preview = apa_preview .. journal .. "."
       end
 
-      local completion_item = {
-        label = key,
-        documentation = {
-          kind = "markdown",
-          value = apa_preview,
-        },
-      }
-
       if key then
-        table.insert(ret, completion_item)
+        table.insert(ret, {
+          label = key,
+          documentation = { kind = "markdown", value = apa_preview },
+        })
       end
     end
   end


### PR DESCRIPTION
Added
- more information in preview of bib-entry;
- formatted preview according to apa (could be set according to user's preferences in the future, reading settings);
- add entry type to preview;
- handle more special characters (umlauts etc) and some commands that might be found in titles and author names;
- support additional citation commands (biblatex: footcite, footcites, parencite etc.) as well as page references "\cite[9]{Niemi2020}" and "\cite[cf.][9]{Niemi2020}".
- (The above includes some personal, custom commands. In the future, one might consider having an optional user config for extending list of "catch-commands" instead of hard-coding custom ones.)

Works when I've tested.